### PR TITLE
Fix: Set nginx to restart always

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,6 +88,15 @@
     - get_install_package is changed
     - hass__data_dir is not defined
 
+- name: Setup nginx service for restarting always
+  template:
+    src: nginx.service
+    dest: /etc/systemd/system/nginx.service
+  notify: Reload nginx service
+  when:
+    - hass__install
+    - hass__configure
+
 - name: Setup nginx config for HA
   template:
     src: hass.conf

--- a/templates/nginx.service
+++ b/templates/nginx.service
@@ -1,0 +1,31 @@
+# Stop dance for nginx
+# =======================
+#
+# ExecStop sends SIGSTOP (graceful stop) to the nginx process.
+# If, after 5s (--retry QUIT/5) nginx is still running, systemd takes control
+# and sends SIGTERM (fast shutdown) to the main process.
+# After another 5s (TimeoutStopSec=5), and if nginx is alive, systemd sends
+# SIGKILL to all the remaining processes in the process group (KillMode=mixed).
+#
+# nginx signals reference doc:
+# http://nginx.org/en/docs/control.html
+#
+[Unit]
+Description=A high performance web server and a reverse proxy server
+Documentation=man:nginx(8)
+After=network.target nss-lookup.target
+
+[Service]
+Type=forking
+Restart=always
+RestartSec=10s
+PIDFile=/run/nginx.pid
+ExecStartPre=/usr/sbin/nginx -t -q -g 'daemon on; master_process on;'
+ExecStart=/usr/sbin/nginx -g 'daemon on; master_process on;'
+ExecReload=/usr/sbin/nginx -g 'daemon on; master_process on;' -s reload
+ExecStop=-/sbin/start-stop-daemon --quiet --stop --retry QUIT/5 --pidfile /run/nginx.pid
+TimeoutStopSec=5
+KillMode=mixed
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Because of some issues, nginx sidecar should restart until it works